### PR TITLE
Fetch all PRs and search in the result

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
             sort: "updated",
             },
             (response, done) => {
-              const paginatedPR = response.data.find(pr => pr.head?.label === head);
+              const paginatedPR = response.data.find(pr => pr.head && pr.head.label === head);
               if (paginatedPR) {
                 pr = paginatedPR;
                 done();

--- a/action.yml
+++ b/action.yml
@@ -34,11 +34,30 @@ runs:
         # forked PRs: https://docs.github.com/en/rest/reference/checks#create-a-check-run
         script: |
           const [owner, repo] = "${{ github.repository }}".split("/");
-          const response = await github.rest.pulls.list({
-            head: "${{ inputs.owner }}:${{ inputs.branch }}",
-            owner,
-            repo,
-          });
-          const [pr] = response.data;
+          const head = "${{ inputs.owner }}:${{ inputs.branch }}";
+
+          // first try: query API using the head param
+          const response = await github.rest.pulls.list({ head, owner, repo });
+          let [pr] = response.data;
+          if (pr) return pr;
+
+          // For some reason GitHub does not always find the PRs querying with the head param:
+          // Fetch all PRs and search for the head.
+          await github.paginate(
+            "GET /repos/{owner}/{repo}/pulls",
+            {
+              owner,
+              repo,
+            sort: "updated",
+            },
+            (response, done) => {
+              const paginatedPR = response.data.find(pr => pr.head?.label === head);
+              if (paginatedPR) {
+                pr = paginatedPR;
+                done();
+              }
+            }
+          );
+
           if (pr) return pr;
           core.setFailed("Pull Request not found!");

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: 🔍 Read PR details
       id: details
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         # We need to find the PR number that corresponds to the branch, which we do by searching the GH API
         # The workflow_run event includes a list of pull requests, but it doesn't get populated for
@@ -51,7 +51,7 @@ runs:
             sort: "updated",
             },
             (response, done) => {
-              const paginatedPR = response.data.find(pr => pr.head && pr.head.label === head);
+              const paginatedPR = response.data.find(pr => pr.head?.label === head);
               if (paginatedPR) {
                 pr = paginatedPR;
                 done();


### PR DESCRIPTION
Fixes not finding some PRs such as https://github.com/matrix-org/matrix-react-sdk/pull/9002

For some reason a query with the head param does not always return a
result. Fetching all PRs return these as well. So we fetch all and then
iterate the results to find the PR we are looking for.